### PR TITLE
Add support for servers configured with SNI

### DIFF
--- a/ctutlz/tls/handshake.py
+++ b/ctutlz/tls/handshake.py
@@ -239,7 +239,7 @@ def do_handshake(domain, scts_tls=True, scts_ocsp=True, timeout=5):
     sock.request_ocsp()
 
     issuer_cert_x509 = None
-    more_issuer_cert_candidates = []
+    more_issuer_cert_x509_candidates = []
     ee_cert_x509 = None
     ocsp_resp_der = None
     tls_ext_18_tdf = None

--- a/ctutlz/tls/handshake.py
+++ b/ctutlz/tls/handshake.py
@@ -236,6 +236,7 @@ def do_handshake(domain, scts_tls=True, scts_ocsp=True, timeout=5):
     '''
     ctx = create_context(scts_tls, scts_ocsp, timeout)
     sock = create_socket(ctx)
+    sock.set_tlsext_host_name(domain.encode())
     sock.request_ocsp()
 
     issuer_cert_x509 = None


### PR DESCRIPTION
This change fixes two things
- A variable in do_handshake was incorrectly named, and caused issues when the SSL handshake failed for some reason
- Support for servers with SNI

There are an increasing amount of servers relying on [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) to correctly serve SSL certificates to the client. I had trouble using verify-sct for a domain configured with Traefik (which uses SNI) and found that this change fixed the problem.

If you would rather have me split these changes in two pull requests, please do tell!